### PR TITLE
Update Wagtail Version Constraints in Setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 # Package dependencies
 install_requires = [
-    'wagtail>=1.8,<=5.0',
+    'wagtail>=1.8,<=5.*',
 ]
 
 # Testing dependencies

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 # Package dependencies
 install_requires = [
-    'wagtail>=1.8,<=5.*',
+    'wagtail>=1.8,<=5.0',
 ]
 
 # Testing dependencies

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 # Package dependencies
 install_requires = [
-    'wagtail>=1.8,<=4.*',
+    'wagtail>=1.8,<=5.0',
 ]
 
 # Testing dependencies


### PR DESCRIPTION
- previously the wagtail version upper bound is `<=4.*`, this is incompatible with v4. (i think it reads as "<= _any v4_", which is equivalent to `<=4.0`)
- updated to `<=5.0` to be compatible with all v4